### PR TITLE
Remove Exception and RuntimeException class

### DIFF
--- a/lib/Exception.php
+++ b/lib/Exception.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Tokenio;
-
-class Exception extends \Exception
-{
-}

--- a/lib/Exception/CryptoKeyNotFoundException.php
+++ b/lib/Exception/CryptoKeyNotFoundException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class CryptoKeyNotFoundException extends Exception
+class CryptoKeyNotFoundException extends \Exception
 {
     /**
      * CryptoKeyNotFoundException constructor.

--- a/lib/Exception/CryptographicException.php
+++ b/lib/Exception/CryptographicException.php
@@ -2,8 +2,6 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class CryptographicException extends Exception
+class CryptographicException extends \Exception
 {
 }

--- a/lib/Exception/IllegalArgumentException.php
+++ b/lib/Exception/IllegalArgumentException.php
@@ -2,8 +2,6 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class IllegalArgumentException extends Exception
+class IllegalArgumentException extends \Exception
 {
 }

--- a/lib/Exception/InvalidRealmException.php
+++ b/lib/Exception/InvalidRealmException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class InvalidRealmException extends Exception
+class InvalidRealmException extends \Exception
 {
     public function __construct($actualRealm, $expectedRealm)
     {

--- a/lib/Exception/InvalidStateException.php
+++ b/lib/Exception/InvalidStateException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class InvalidStateException extends Exception
+class InvalidStateException extends \Exception
 {
     /**
      * InvalidStateException constructor.

--- a/lib/Exception/InvalidUnsecuredFileSystemKeyStoreConfiguration.php
+++ b/lib/Exception/InvalidUnsecuredFileSystemKeyStoreConfiguration.php
@@ -2,8 +2,6 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\RuntimeException;
-
-class InvalidUnsecuredFileSystemKeyStoreConfiguration extends RuntimeException
+class InvalidUnsecuredFileSystemKeyStoreConfiguration extends \RuntimeException
 {
 }

--- a/lib/Exception/StatusRuntimeException.php
+++ b/lib/Exception/StatusRuntimeException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\RuntimeException;
-
-class StatusRuntimeException extends RuntimeException
+class StatusRuntimeException extends \RuntimeException
 {
 
     public function __construct($code, $description)

--- a/lib/Exception/StepUpRequiredException.php
+++ b/lib/Exception/StepUpRequiredException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class StepUpRequiredException extends Exception
+class StepUpRequiredException extends \Exception
 {
     public function __construct($message)
     {

--- a/lib/Exception/VerificationException.php
+++ b/lib/Exception/VerificationException.php
@@ -2,9 +2,7 @@
 
 namespace Tokenio\Exception;
 
-use Tokenio\Exception;
-
-class VerificationException extends Exception
+class VerificationException extends \Exception
 {
     private $status;
 

--- a/lib/RuntimeException.php
+++ b/lib/RuntimeException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Tokenio;
-
-class RuntimeException extends \RuntimeException
-{
-}


### PR DESCRIPTION
Removing `Exception` and `RuntimeException` class and make other exceptions extend the php `\Exception` and `\RuntimeException` class, unless of course it is a good practice to create your own `Exception` and `RuntimeException` somehow?