### PR TITLE
GRPC updated to version 1.36 [BC break]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a75315965bcc27556c1a315e9c153fdd",
+    "content-hash": "b39cd44dbbb8032fbfce152ecb41db05",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -535,20 +535,20 @@
         },
         {
             "name": "grpc/grpc",
-            "version": "1.22.0",
+            "version": "1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "88235e786ef9b55fcb049f00c5c5202f8086a299"
+                "reference": "6145dd917d340b579f0b663940b17cc93172b79a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/88235e786ef9b55fcb049f00c5c5202f8086a299",
-                "reference": "88235e786ef9b55fcb049f00c5c5202f8086a299",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/6145dd917d340b579f0b663940b17cc93172b79a",
+                "reference": "6145dd917d340b579f0b663940b17cc93172b79a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0"
+                "php": ">=7.0.0"
             },
             "require-dev": {
                 "google/auth": "^v1.3.0"
@@ -572,7 +572,7 @@
             "keywords": [
                 "rpc"
             ],
-            "time": "2019-07-03T19:57:39+00:00"
+            "time": "2021-03-01T21:52:11+00:00"
         },
         {
             "name": "jms/metadata",

--- a/lib/Rpc/Interceptor/ClientAuthenticatorInterceptor.php
+++ b/lib/Rpc/Interceptor/ClientAuthenticatorInterceptor.php
@@ -37,9 +37,9 @@ class ClientAuthenticatorInterceptor extends Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+	                                    $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         /** @var Message $argument */
         $now = round(microtime(true) * 1000);
@@ -64,6 +64,6 @@ class ClientAuthenticatorInterceptor extends Interceptor
             AuthenticationContext::clearAccessToken();
         }
 
-        return parent::interceptUnaryUnary($method, $argument, $deserialize, $metadata, $options, $continuation);
+        return parent::interceptUnaryUnary($method, $argument, $deserialize, $continuation, $metadata, $options);
     }
 }

--- a/lib/Rpc/Interceptor/MetadataInterceptor.php
+++ b/lib/Rpc/Interceptor/MetadataInterceptor.php
@@ -21,11 +21,11 @@ class MetadataInterceptor extends Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+	                                    $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         $metadata = array_merge($metadata, $this->metadata);
-        return parent::interceptUnaryUnary($method, $argument, $deserialize, $metadata, $options, $continuation);
+        return parent::interceptUnaryUnary($method, $argument, $deserialize, $continuation, $metadata, $options);
     }
 }

--- a/lib/Rpc/Interceptor/TimeoutInterceptor.php
+++ b/lib/Rpc/Interceptor/TimeoutInterceptor.php
@@ -25,11 +25,11 @@ class TimeoutInterceptor extends Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+	                                    $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         $options['timeout'] = ($this->timeout * 1000);
-        return parent::interceptUnaryUnary($method, $argument, $deserialize, $metadata, $options, $continuation);
+        return parent::interceptUnaryUnary($method, $argument, $deserialize, $continuation, $metadata, $options);
     }
 }


### PR DESCRIPTION
The [1.36 release of gRPC](https://github.com/grpc/grpc/releases/tag/v1.36.0) includes the following "fix" for PHP8: https://github.com/grpc/grpc/pull/25019

Unfortunately this causes a breaking change in consumer libraries as it adjusts the order of parameter declarations. This means that if a client upgrades their gRPC engine version (not constrainable by `composer.json`) the package will likely break.

At the same time, if the client has _not_ updated their gRPC engine version then this change would break it. Therefore this would need to be considered a major version bump.